### PR TITLE
Install location shared between event handlers

### DIFF
--- a/Borderlands2Patcher/Form1.Designer.cs
+++ b/Borderlands2Patcher/Form1.Designer.cs
@@ -28,7 +28,6 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
             this.button1 = new System.Windows.Forms.Button();
             this.button2 = new System.Windows.Forms.Button();
             this.textBox1 = new System.Windows.Forms.TextBox();
@@ -39,10 +38,6 @@
             this.comboBox1 = new System.Windows.Forms.ComboBox();
             this.linkLabel2 = new System.Windows.Forms.LinkLabel();
             this.SuspendLayout();
-            // 
-            // openFileDialog1
-            // 
-            this.openFileDialog1.FileName = "Borderlands2.exe";
             // 
             // button1
             // 
@@ -152,8 +147,6 @@
         }
 
         #endregion
-
-        private System.Windows.Forms.OpenFileDialog openFileDialog1;
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Button button2;
         private System.Windows.Forms.TextBox textBox1;

--- a/Borderlands2Patcher/Form1.Designer.cs
+++ b/Borderlands2Patcher/Form1.Designer.cs
@@ -145,6 +145,7 @@
             this.Controls.Add(this.button1);
             this.Name = "Form1";
             this.Text = "Borderlands  Patcher";
+            this.Shown += new System.EventHandler(this.Form1_Shown);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/Borderlands2Patcher/Form1.cs
+++ b/Borderlands2Patcher/Form1.cs
@@ -15,27 +15,8 @@ namespace Borderlands2Patcher
 {
     public partial class Form1 : Form
     {
-        private static string b2il
-        {
-            get
-            {
-                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 49520"))
-                {
-                    return key.GetValue("InstallLocation") as string;
-                }
-            }
-        }
-
-        private static string btpsil
-        {
-            get
-            {
-                using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 261640"))
-                {
-                    return key.GetValue("InstallLocation") as string;
-                }
-            }
-        }
+        private string b2il = String.Empty;
+        private string btpsil = String.Empty;
 
         public Form1()
         {
@@ -60,6 +41,29 @@ namespace Borderlands2Patcher
 
         bool isBorderlands2 = true;
 
+        private void Form1_Shown(object sender, EventArgs e)
+        {
+            // get install path of Borderlands 2
+            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 49520"))
+            {
+                if (key != null)
+                {
+                    b2il = key.GetValue("InstallLocation") as string;
+                }
+                // else key could not be found
+            }
+
+            // get install path of Borderlands The PreSequel
+            using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Steam App 261640"))
+            {
+                if (key != null)
+                {
+                    btpsil = key.GetValue("InstallLocation") as string;
+                }
+                // else key could not be found
+            }
+        }
+
         private void button1_Click(object sender, EventArgs e)
         {
             DialogResult result = new DialogResult();
@@ -67,10 +71,20 @@ namespace Borderlands2Patcher
             {
                 if (isBorderlands2)
                 {
+                    if (String.IsNullOrEmpty(b2il))
+                    {
+                        throw new NullReferenceException();
+                    }
+
                     openFileDialog1.FileName = b2il + "\\Binaries\\Win32\\Borderlands2.exe";
                 }
                 else
                 {
+                    if (String.IsNullOrEmpty(btpsil))
+                    {
+                        throw new NullReferenceException();
+                    }
+
                     openFileDialog1.FileName = btpsil + "\\Binaries\\Win32\\BorderlandsPreSequel.exe";
                 }
                 result = DialogResult.OK;
@@ -184,6 +198,11 @@ namespace Borderlands2Patcher
 
                 try
                 {
+                    if (String.IsNullOrEmpty(path))
+                    {
+                        throw new NullReferenceException();
+                    }
+
                     File.WriteAllLines(path + "\\Binaries\\Patch.txt", content);
                     File.WriteAllLines(path + "\\Binaries\\PatchOffline.txt", contentOffline);
                     MessageBox.Show("Done!");

--- a/Borderlands2Patcher/Form1.resx
+++ b/Borderlands2Patcher/Form1.resx
@@ -117,9 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="openFileDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="folderBrowserDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>157, 17</value>
   </metadata>


### PR DESCRIPTION
8bc1e97
Repeatedly accessing the same Registry key (even when it doesn't exist) doesn't make much sense, so I reduced the total number of accesses to two. Registry key accesses occur when the window is done being rendered so it can be displayed faster.

de2fcc2
It was mildly inconvenient to be asked twice for the install location (once for the exe edit and again for the patch download), so the user is only asked once and the selected folder value is saved.

9ce3dcb
The OpenFileDialog resource wasn't used anymore and was removed.